### PR TITLE
overview imageGallery Update

### DIFF
--- a/public/dist/style.css
+++ b/public/dist/style.css
@@ -353,7 +353,8 @@ li.carousel-card > img {
 
 #imageGallery {
   background-color: transparent;
-  max-height: 518px;
+  max-height: 510px;
+  min-height: 510px;
   overflow-y: scroll;
 
 }

--- a/src/components/overview/expandedView.jsx
+++ b/src/components/overview/expandedView.jsx
@@ -97,7 +97,7 @@ const ExpandedView = (props) => {
       <div id='Small_Gallery_Container'>
         {mainPhotos.map((photos) => {
           return (<div className='Small_Thumbnail_Container'>
-            <img className='Small_Thumbnail' src={photos.url} onClick={() => {showSelected(photos.url)}}></img>
+            <img className='Small_Thumbnail' src={photos.thumbnail_url} onClick={() => {showSelected(photos.url)}}></img>
             <div id={photos.url} className='hide selectColor' ></div>
           </div>);
         })}
@@ -125,7 +125,7 @@ const ExpandedView = (props) => {
     </div>
 
       <div id='closeButton' className={(zoom) ? 'hide' : 'show'}>
-        <div onClick={() => {props.setExpandedView(false)}}><GrClose size={20} /></div>
+        <div onClick={() => {props.setExpandedView(false); props.setResetMain(true); }}><GrClose size={20} /></div>
       </div>
     </div>
   );

--- a/src/components/overview/image.jsx
+++ b/src/components/overview/image.jsx
@@ -10,22 +10,28 @@ import { RxCaretUp, RxCaretDown, RxCaretRight, RxCaretLeft } from "react-icons/r
 const ImageGallery = (props) => {
   const { mainProduct, styles, mainPhotos } = useSelector((state) => state.overview); // store.slice
 
+
+  const [main, setMain] = useState('');
+
   useEffect(() => {
     if (mainPhotos[0] !== undefined) {
-      setMain(mainPhotos[0].url);
+      if (props.resetMain) {
+        setMain(props.expandedMain);
+        props.setResetMain(false);
+      } else{
+        setMain(mainPhotos[0].url);
+      }
     }
   }, [mainPhotos]);
 
 
-  const [main, setMain] = useState('');
+
 
 
   useEffect(() => {
     if (main && main.length > 0) {
-
       props.setExpandedMain(main);
       document.getElementById(main).scrollIntoView({behavior: 'smooth', block: 'end'});
-
     }
   }, [main]);
 
@@ -73,8 +79,8 @@ const ImageGallery = (props) => {
            <div id='upButton' className={(mainPhotos.length <= 7) ? 'hide' : ''} onClick={() => { document.getElementById('imageGallery').scrollBy(0, -74)}}><RxCaretUp size={30}/></div>
             <div id='imageGallery'>
               {mainPhotos.map((photo) => {
-                return <div onClick={() => { setMain(photo.url); }} key={photo.url} value='test'>
-                  <img className='imageGalleryItem' src={photo.url}></img>
+                return <div onClick={() => { setMain(photo.url); }} value='test'>
+                  <img className='imageGalleryItem' src={photo.thumbnail_url}></img>
                   <div className='selectorSpace'>
                     <div id={photo.url} className={(main === photo.url) ? 'show selectColor' : 'hide selectColor'}></div>
                   </div>

--- a/src/components/overview/image.jsx
+++ b/src/components/overview/image.jsx
@@ -12,7 +12,7 @@ const ImageGallery = (props) => {
 
 
   const [main, setMain] = useState('');
-
+  //comment
   useEffect(() => {
     if (mainPhotos[0] !== undefined) {
       if (props.resetMain) {

--- a/src/components/overview/overview.jsx
+++ b/src/components/overview/overview.jsx
@@ -12,6 +12,7 @@ const Overview = () => {
 
   const [expandedView, setExpandedView] = useState(false);
   const [expandedMain, setExpandedMain] = useState('');
+  const [resetMain, setResetMain] = useState(false);
 
   useEffect(() => {
     async function fetchData() {
@@ -78,6 +79,9 @@ const Overview = () => {
             <ImageGallery
               setExpandedView={setExpandedView}
               setExpandedMain={setExpandedMain}
+              expandedMain={expandedMain}
+              setResetMain={setResetMain}
+              resetMain={resetMain}
             />
           </div>
         ) : (
@@ -95,6 +99,7 @@ const Overview = () => {
             <ExpandedView
               setExpandedView={setExpandedView}
               expandedMain={expandedMain}
+              setResetMain={setResetMain}
             />
           </div>
         ) : (

--- a/src/components/overview/styleSelector.jsx
+++ b/src/components/overview/styleSelector.jsx
@@ -14,6 +14,7 @@ const StyleSelector = (props) => {
 
   //This sets the checkMark Variable automatically at render w/ the first thumbnail on list
   useEffect(() => {
+    console.log('----> styles', styles);
     if (styles.results === undefined) {
       dispatch(setSelectedstyle({}));
     } else {
@@ -67,12 +68,13 @@ const StyleSelector = (props) => {
     }
 
     //Change the redux state so that the big display photo displays all the photos from the selected style
+    console.log('======>', data.photos);
     dispatch(setMainPhotos(data.photos));
   };
 
   return (Object.keys(styles).length) ? (
     <div id='styleContainer'>
-      <span><b>{'STYLE>  '}</b></span>
+      <span onClick={() => {console.log(mainProduct)}}><b>{'STYLE>  '}</b></span>
        <span id='productStyle'>{styles.results[0].name}</span>
       <div>
         <ul id='styleSelector'>


### PR DESCRIPTION
@BradySBaker @danny-avila @matthewrmcivor 

First commit didnt work for some reason but here is what I did 

Image Gallery for both expanded view and normal view changed from full URL res to thumbnail url res. 
Main photo for both are still in full res 

Fixed a bug: when switching from expandedview to normal view, the normal view would always render the first photo in the imageGallery scroll down. However, now it will return back to the image that was originally clicked (no restart and goes back to where the consumer left off)

spoke to @danny-avila about the small bug, will fix on my end in next PR but will be awesome if we can both consider it.